### PR TITLE
prepare-commit-msg git hook to extract Linear issue number

### DIFF
--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Get the current branch name
+branch_name="$(git rev-parse --abbrev-ref HEAD)"
+
+# Extract the issue key from the branch name
+issue_key="$(echo "$branch_name" | grep -oE 'ENG-[0-9]+')"
+
+# Check if an issue key was found
+if [ -n "$issue_key" ]; then
+  echo ""
+  # Prepend the issue key and #time to the commit message
+  sed -i.bak -e "1s/^/$issue_key #time /" "$1"
+fi

--- a/install_git_hooks.sh
+++ b/install_git_hooks.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Check if the current directory is within a Git repository
+if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+  echo "Error: Not inside a Git repository."
+  exit 1
+fi
+
+git_top_level=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ $? -ne 0 ]; then
+    echo "ERROR: Could not extract the top of the workspace"
+    exit 1
+fi
+
+# Create a temporary directory
+temp_dir="$(mktemp -d)"
+
+# Clone the repository into the temporary directory
+git clone git@github.com:Maia-Tech/tools-git-hooks.git "$temp_dir"
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to clone the tools-git-hooks repo"
+    exit 1
+fi
+
+# Copy the prepare-commit-msg hook file to the .git/hooks directory
+cp "$temp_dir/hooks/prepare-commit-msg" ".git/hooks/"
+
+# Make the hook file executable
+chmod +x ".git/hooks/prepare-commit-msg"
+
+# Clean up the temporary directory
+rm -rf "$temp_dir"
+
+echo "prepare-commit-msg hook installed successfully."

--- a/install_git_hooks.sh
+++ b/install_git_hooks.sh
@@ -16,7 +16,7 @@ fi
 temp_dir="$(mktemp -d)"
 
 # Clone the repository into the temporary directory
-git clone git@github.com:Maia-Tech/tools-git-hooks.git "$temp_dir"
+git clone git@github.com:Maia-Tech/tools-git-hooks.git "$temp_dir" > /dev/null 2>&1
 if [ $? -ne 0 ]; then
     echo "Error: Failed to clone the tools-git-hooks repo"
     exit 1


### PR DESCRIPTION
Create a simple `prepare-commit-msg` hook to extract the Linear issue number from the branch name and put it in the commit message.

A simple wrapper script, `install_git_hooks.sh` was also created to make it simple to install this git hook into any git workspace via:
```
curl -s https://raw.githubusercontent.com/Maia-Tech/tools-git-hooks/acormier/ENG-61-precommit-hook/install_git_hooks.sh | bash
```

ENG-61 #time 30m