### PR TITLE
Ensure Linear ID is placed below comment when -m is provided to git commit

### DIFF
--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# This script is used to add the issue key to the commit message
+# When used with the --message or --file option, it appends the issue key to the end of the commit message
+# Otherwise, it prepends the issue key to the commit message in a way which makes it
+# convenient to use with an editor
 
 COMMIT_MSG_FILE=$1
 COMMIT_SOURCE=$2
@@ -18,6 +23,11 @@ branch_name="$(git rev-parse --abbrev-ref HEAD)"
 issue_key="$(echo "$branch_name" | grep -ioE 'ENG-[0-9]+' | tr '[:lower:]' '[:upper:]')"
 
 if [[ -n "$issue_key" ]]; then
-  # Prepend the issue key and #time to the commit message
-  sed -i.bak -e "1s/^/\n\n$issue_key /" "$1"
+  if [ "$COMMIT_SOURCE" == "message" ]; then
+    # Append the issue key to the end of the commit message for message source
+    echo -e "\n$issue_key" >> "$COMMIT_MSG_FILE"
+  else
+    # Prepend the issue key to the commit message for other sources
+    sed -i.bak -e "1s/^/\n\n$issue_key /" "$COMMIT_MSG_FILE"
+  fi
 fi


### PR DESCRIPTION
When using vscode, I was noticing that the linear ID was being put at the beginning of the commit message.  We needed to add a bit of additional logic here to make sure the ID is placed at the end of the message when `-m` is provided to git commit.

ENG-747