### PR TITLE
Add semantic commits git hook

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Taken from https://github.com/hazcod/semantic-commit-hook
+#
+
+if [ -z "$1" ]; then
+	echo "Missing argument (commit message). Did you try to run this manually?"
+	exit 1
+fi
+
+commitTitle="$(cat $1 | head -n1)"
+
+# ignore merge requests
+if echo "$commitTitle" | grep -qE "Merge branch"; then
+	echo "Commit hook: ignoring branch merge"
+	exit 0
+fi
+
+# check semantic versioning scheme
+if ! echo "$commitTitle" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|chore|build|ci|revert)(\([a-z0-9\s\-\_\,]+\))?!?:\s\w'; then
+	echo "Your commit message did not follow semantic versioning: $commitTitle"
+	echo ""
+	echo "Format:   <type>(<optional-scope>): <subject>"
+	echo "Example:  feat(api): add endpoint"
+	echo ""
+	echo "Valid types: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test"
+	echo ""
+	echo "Please see"
+	echo "- https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commit-message-format"
+	echo "- https://www.conventionalcommits.org/en/v1.0.0/#summary"
+	exit 1
+fi

--- a/install_git_hooks.sh
+++ b/install_git_hooks.sh
@@ -22,8 +22,10 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Copy the prepare-commit-msg hook file to the .git/hooks directory
-cp "$temp_dir/hooks/prepare-commit-msg" ".git/hooks/"
+# Copy the hook files to the .git/hooks directory
+for hook in prepare-commit-msg commit-msg; do
+    cp "$temp_dir/hooks/${hook}" ".git/hooks/"
+done
 
 # Make the hook file executable
 chmod +x ".git/hooks/prepare-commit-msg"


### PR DESCRIPTION
Adds the `commit-msg` hook which verifies that the commit message follows semantic commits.

To install (once this is merged):

```
curl -s https://raw.githubusercontent.com/Maia-Tech/tools-git-hooks/main/install_git_hooks.sh | bash
```